### PR TITLE
Observations are re-created on Registration Update events. This does …

### DIFF
--- a/lib/services/lwm2mHandlers/updateRegistration.js
+++ b/lib/services/lwm2mHandlers/updateRegistration.js
@@ -23,7 +23,6 @@
 'use strict';
 
 var iotAgentLib = require('iotagent-node-lib'),
-    lwm2mLib = require('lwm2m-node-lib').server,
     commonLwm2m = require('./commonLwm2m'),
     logger = require('logops'),
     async = require('async'),
@@ -41,34 +40,7 @@ var iotAgentLib = require('iotagent-node-lib'),
 function updateRegistration(device, payload, callback) {
     logger.debug(context, 'Handling update registration of the device');
 
-    function removePreviousSubscriptions(callback) {
-        lwm2mLib.listObservers(function observersHandler(error, observersList) {
-            if (error) {
-                callback(error);
-            } else {
-                var cancellations = [];
-                for (var i = 0; i < observersList.length; i++) {
-                    if (observersList[i].deviceId.toString() === device.id.toString()) {
-                        var fields = lwm2mLib.parseObserverId(observersList[i].id);
-
-                        cancellations.push(apply(lwm2mLib.cancelObserver,
-                            fields.deviceId,
-                            fields.objectType,
-                            fields.objectId,
-                            fields.resourceId
-                        ));
-                    }
-                }
-
-                async.series(cancellations, function(error, results) {
-                    callback(error);
-                });
-            }
-        });
-    }
-
     async.waterfall([
-        removePreviousSubscriptions,
         apply(iotAgentLib.getDevice, device.name),
         apply(commonLwm2m.observeActiveAttributes, payload)
     ], callback);


### PR DESCRIPTION
…not work if payload does not contains object list (only occurs in registration process)
