### PR TITLE
Avoid remove/create observers again if update registration payload is…

### DIFF
--- a/lib/services/lwm2mHandlers/updateRegistration.js
+++ b/lib/services/lwm2mHandlers/updateRegistration.js
@@ -67,11 +67,24 @@ function updateRegistration(device, payload, callback) {
         });
     }
 
-    async.waterfall([
-        removePreviousSubscriptions,
-        apply(iotAgentLib.getDevice, device.name),
-        apply(commonLwm2m.observeActiveAttributes, payload)
-    ], callback);
+    // If payload does not contain the list of objects/instances (usually this is only included if objects has changed since registration)
+    if (!payload && payload==="") {
+
+        async.waterfall([
+            apply(iotAgentLib.getDevice, device.name),
+        ], callback);
+
+    } else {
+
+        // Remove and create again observations
+        async.waterfall([
+            removePreviousSubscriptions,
+            apply(iotAgentLib.getDevice, device.name),
+            apply(commonLwm2m.observeActiveAttributes, payload)
+        ], callback);
+
+    }
+
 }
 
 exports.handler = updateRegistration;


### PR DESCRIPTION
… empty.
